### PR TITLE
Support ObjectValidationResult style for the validation method

### DIFF
--- a/src/Props/Columns.fs
+++ b/src/Props/Columns.fs
@@ -1,9 +1,15 @@
-﻿namespace Feliz.MaterialUI.MaterialTable
+namespace Feliz.MaterialUI.MaterialTable
 
 open Fable.Core
 open Fable.Core.JsInterop
 open Feliz
 open System
+
+type ObjectValidationResult =
+    {
+        isValid : bool
+        helperText : string
+    }
 
 [<Erase>]
 type column =
@@ -135,6 +141,8 @@ type column =
     static member inline validate<'T> (handler: 'T -> Result<unit,string>) = Interop.mkColumnAttr "validate" (handler >> Bindings.Validation.fromResult)
     /// Validates column data
     static member inline validate<'T> (handler: 'T -> string) = Interop.mkColumnAttr "validate" handler
+    /// Validates column data
+    static member inline validate<'T> (handler: 'T -> ObjectValidationResult) = Interop.mkColumnAttr "validate" handler
 
     /// Width of the column in px
     static member inline width (value: int) = Interop.mkColumnAttr "width" value


### PR DESCRIPTION
On F# slack, someone had a hard time making `validate` works.

During the process helping him, I discover that not all the `validate` style are binded in this library.

This PR add a record to allow using the "Object Validation" style from https://material-table.com/#/docs/features/validation.

I am unsure if the record should be marked as `Erased` or not to minimize the bundle size. The problem if we mark it `Erased` is that reflection will not work on it but nothing will prevent the user from trying to do it.